### PR TITLE
Reorder layouts, fix transparency, fullscreen grid, solo reveal, play…

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
     <div class="particles" id="particles"></div>
     <div class="stars" id="stars"></div>
-    <div class="container final">
+    <div class="container plain">
         <div class="letter B" data-narrative="shores">
             B <span class="braille">⠃</span>
             <div class="word">
@@ -142,6 +142,12 @@
     <!-- Mobile showcase navigation -->
     <div class="showcase-dots" id="showcaseDots"></div>
     <div class="swipe-hint" id="swipeHint">swipe to explore</div>
+
+    <!-- Play / Pause -->
+    <button class="play-pause-btn" id="playPauseBtn" title="Pause animation">
+        <svg class="pp-pause" width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16" rx="1"/><rect x="14" y="4" width="4" height="16" rx="1"/></svg>
+        <svg class="pp-play" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="display:none"><polygon points="6,4 20,12 6,20"/></svg>
+    </button>
 
     <div class="flag-credit">Code Vibed by: Hasan AlDoy - Radio Bahrain 2025</div>
 

--- a/script.js
+++ b/script.js
@@ -406,11 +406,42 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   };
 
-  // Set initial states
+  // Set initial states — letters are ALWAYS fully opaque
   gsap.set(words, { opacity: 0, y: 20 });
   gsap.set(narratives, { opacity: 0, y: 30, scale: 0.9 });
   gsap.set([kingdom, bahrain], { opacity: 0, display: 'none' });
   gsap.set(letters, { scale: 1, opacity: 1 });
+
+  // ═══════════════════════════════════════════
+  // PLAY / PAUSE CONTROL
+  // ═══════════════════════════════════════════
+  const playPauseBtn = document.getElementById('playPauseBtn');
+  const ppPause = playPauseBtn.querySelector('.pp-pause');
+  const ppPlay = playPauseBtn.querySelector('.pp-play');
+  let isPaused = false;
+
+  playPauseBtn.addEventListener('click', () => {
+    isPaused = !isPaused;
+    playPauseBtn.classList.toggle('paused', isPaused);
+    ppPause.style.display = isPaused ? 'none' : 'block';
+    ppPlay.style.display = isPaused ? 'block' : 'none';
+    playPauseBtn.title = isPaused ? 'Play animation' : 'Pause animation';
+
+    if (isPaused) {
+      clearTimeout(loopTimeout);
+      stopShowcaseAuto();
+      clearTimeout(soloTimer);
+    } else {
+      // Resume
+      if (isMobile && container.classList.contains('showcase')) {
+        startShowcaseAuto();
+      } else if (container.classList.contains('solo')) {
+        advanceSoloLetter();
+      } else {
+        loopTimeout = setTimeout(animationLoop, 1500);
+      }
+    }
+  });
 
   // Particle System
   class ParticleSystem {
@@ -827,10 +858,9 @@ document.addEventListener('DOMContentLoaded', function () {
   // ═══════════════════════════════════════════
   // ENTER / EXIT MOBILE SHOWCASE MODE
   // ═══════════════════════════════════════════
-  const allLayouts = ['final', 'plain', 'columns', 'rows', 'grid', 'showcase'];
 
   function enterShowcaseMode() {
-    container.classList.remove('final', 'plain', 'columns', 'rows', 'grid');
+    container.classList.remove('final', 'plain', 'columns', 'rows', 'grid', 'solo');
     container.classList.add('showcase');
     showcaseDots.classList.add('visible');
     swipeHint.classList.add('visible');
@@ -864,34 +894,46 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   // ═══════════════════════════════════════════
-  // DESKTOP LAYOUT CYCLING (original behavior)
+  // LAYOUT CYCLING ENGINE
   // ═══════════════════════════════════════════
-  const layouts = ['final', 'plain', 'columns', 'rows', 'grid'];
-  let currentLayout = 0;
+  // Order: plain → final → columns → rows → grid → solo (one-by-one) → loop
+  const layouts = ['plain', 'final', 'columns', 'rows', 'grid'];
+  const ALL_LAYOUT_CLASSES = ['plain', 'final', 'columns', 'rows', 'grid', 'solo', 'showcase'];
+  let currentLayout = 0;       // starts at plain
   let animationInProgress = false;
   let loopTimeout;
-  let finalRevealTriggered = false;
+  let soloTimer;
+  let soloIndex = 0;
+
+  // Helper: ensure letters never go transparent
+  function ensureLettersVisible() {
+    gsap.set(letters, { opacity: 1 });
+  }
 
   async function changeLayout() {
-    if (animationInProgress) return;
+    if (animationInProgress || isPaused) return;
     animationInProgress = true;
 
     try {
+      // ── Hide words/narratives/kingdom before FLIP ──
       gsap.killTweensOf([words, narratives, kingdom, bahrain]);
 
       const hideTl = gsap.timeline({ defaults: { duration: 0.4, ease: "power2.in" } });
       hideTl.to([words, narratives], { opacity: 0, y: 15, scale: 0.92 }, 0);
       hideTl.to([kingdom, bahrain], { opacity: 0 }, 0);
-
       await hideTl;
 
+      // Letters stay fully visible
+      ensureLettersVisible();
+
+      // ── Capture → switch → FLIP ──
       const state = Flip.getState(letters, {
-        props: "transform,filter,opacity,width,height,margin,padding",
+        props: "transform,filter,width,height,margin,padding",
         simple: true,
         tolerance: 0.01
       });
 
-      container.classList.remove(...layouts);
+      container.classList.remove(...ALL_LAYOUT_CLASSES);
       currentLayout = (currentLayout + 1) % layouts.length;
       container.classList.add(layouts[currentLayout]);
 
@@ -899,19 +941,22 @@ document.addEventListener('DOMContentLoaded', function () {
         Flip.from(state, {
           duration: 1.6,
           ease: "power3.inOut",
-          stagger: {
-            amount: 0.45,
-            from: "center"
-          },
+          stagger: { amount: 0.45, from: "center" },
           scale: true,
           simple: true,
           onComplete: resolve
         });
       });
 
-      const appearTl = gsap.timeline();
+      // Letters stay visible after FLIP
+      ensureLettersVisible();
 
-      if (layouts[currentLayout] === 'final') {
+      // ── Reveal content for new layout ──
+      const appearTl = gsap.timeline();
+      const layout = layouts[currentLayout];
+
+      if (layout === 'final') {
+        gsap.set([kingdom, bahrain], { display: 'block' });
         appearTl.to([kingdom, bahrain], {
           duration: 2.2,
           opacity: 1,
@@ -922,38 +967,20 @@ document.addEventListener('DOMContentLoaded', function () {
         }, 0.6);
       }
 
-      if (layouts[currentLayout] === 'grid') {
-        appearTl.to(letters, {
-          scale: 0.68,
-          duration: 1.2,
-          ease: "power2.out",
-          stagger: 0.06
-        }, 0.3);
-
+      if (layout === 'grid') {
         appearTl.to(words, {
-          opacity: 1,
-          y: 0,
+          opacity: 1, y: 0,
           duration: 1.4,
           ease: "back.out(1.6)",
           stagger: 0.08
-        }, 0.8);
+        }, 0.6);
 
         appearTl.to(narratives, {
-          opacity: 1,
-          y: 0,
-          scale: 1,
+          opacity: 1, y: 0, scale: 1,
           duration: 1.6,
           ease: "power3.out",
           stagger: 0.1
-        }, 1);
-      } else {
-        appearTl.to(words, {
-          opacity: 0.85,
-          y: 0,
-          duration: 1,
-          ease: "power2.out",
-          stagger: 0.07
-        }, 0.6);
+        }, 0.9);
       }
 
       await appearTl;
@@ -963,12 +990,140 @@ document.addEventListener('DOMContentLoaded', function () {
     } finally {
       animationInProgress = false;
 
-      const delay = layouts[currentLayout] === 'grid' ? 9000 : 3800;
-      loopTimeout = setTimeout(animationLoop, delay);
+      // After grid → enter solo mode; otherwise schedule next
+      if (layouts[currentLayout] === 'grid') {
+        loopTimeout = setTimeout(enterSoloMode, 8000);
+      } else {
+        const delay = layouts[currentLayout] === 'final' ? 5000 : 3800;
+        loopTimeout = setTimeout(animationLoop, delay);
+      }
     }
   }
 
+  // ═══════════════════════════════════════════
+  // SOLO ONE-BY-ONE REVEAL
+  // ═══════════════════════════════════════════
+  function enterSoloMode() {
+    if (isPaused) return;
+
+    // Clean up
+    gsap.killTweensOf([words, narratives, kingdom, bahrain]);
+    gsap.set([words, narratives], { opacity: 0 });
+    gsap.set([kingdom, bahrain], { opacity: 0 });
+
+    container.classList.remove(...ALL_LAYOUT_CLASSES);
+    container.classList.add('solo');
+
+    // Hide all letters, then reveal one by one
+    letters.forEach(l => {
+      l.classList.remove('solo-active');
+      gsap.set(l, { opacity: 0, scale: 0.7, x: 0, y: 0 });
+    });
+
+    soloIndex = 0;
+    advanceSoloLetter();
+  }
+
+  function advanceSoloLetter() {
+    if (isPaused) return;
+
+    // If we've shown all 7, exit solo → loop back to plain
+    if (soloIndex >= letters.length) {
+      exitSoloMode();
+      return;
+    }
+
+    const letter = letters[soloIndex];
+    const word = letter.querySelector('.word');
+    const narrative = letter.querySelector('.narrative');
+    const narrativeType = letter.dataset.narrative;
+    const storyArc = characterNarratives[narrativeType];
+
+    // Hide previous
+    if (soloIndex > 0) {
+      const prev = letters[soloIndex - 1];
+      const prevWord = prev.querySelector('.word');
+      const prevNarr = prev.querySelector('.narrative');
+      gsap.to(prev, { opacity: 0, scale: 0.7, duration: 0.5, ease: "power2.in" });
+      gsap.to(prevWord, { opacity: 0, y: 15, duration: 0.3 });
+      gsap.to(prevNarr, { opacity: 0, y: 15, duration: 0.3 });
+      prev.classList.remove('solo-active');
+    }
+
+    // Show current letter
+    letter.classList.add('solo-active');
+    const tl = gsap.timeline();
+
+    // Letter appears: center of viewport
+    tl.to(letter, {
+      opacity: 1,
+      scale: 1,
+      duration: 0.8,
+      ease: "back.out(1.4)"
+    }, 0.3);
+
+    // Particles burst
+    tl.call(() => {
+      const pc = letter.querySelector('.particles-container');
+      if (pc) {
+        const pType = storyArc.emotion === 'wonder' ? 'gold' :
+                      storyArc.emotion === 'warmth' ? 'silver' : 'default';
+        new ParticleSystem(pc, pType).start();
+      }
+    }, null, 0.6);
+
+    // Word fades in slowly
+    tl.to(word, {
+      opacity: 1,
+      y: 0,
+      duration: 1.2,
+      ease: "power2.out"
+    }, 1.0);
+
+    // Narrative fades in slowly
+    tl.to(narrative, {
+      opacity: 1,
+      y: 0,
+      scale: 1,
+      duration: 1.4,
+      ease: "power3.out"
+    }, 1.6);
+
+    soloIndex++;
+
+    // Wait for the full reveal + reading time, then advance
+    soloTimer = setTimeout(advanceSoloLetter, 6000);
+  }
+
+  function exitSoloMode() {
+    clearTimeout(soloTimer);
+
+    // Hide last solo letter
+    letters.forEach(l => {
+      l.classList.remove('solo-active');
+    });
+
+    container.classList.remove('solo');
+    container.classList.add('plain');
+    currentLayout = 0;
+
+    // Reset everything cleanly for the next loop
+    gsap.set(letters, { opacity: 1, scale: 1, x: 0, y: 0, clearProps: 'position,width,height' });
+    gsap.set(words, { opacity: 0, y: 20 });
+    gsap.set(narratives, { opacity: 0, y: 30, scale: 0.9 });
+    gsap.set([kingdom, bahrain], { opacity: 0 });
+
+    if (!isPaused) {
+      loopTimeout = setTimeout(animationLoop, 3000);
+    }
+  }
+
+  // ═══════════════════════════════════════════
+  // MAIN ANIMATION LOOP
+  // ═══════════════════════════════════════════
   async function animationLoop() {
+    if (isPaused) return;
+
     // If mobile, use showcase mode instead
     if (isMobile) {
       if (!container.classList.contains('showcase')) {
@@ -980,32 +1135,38 @@ document.addEventListener('DOMContentLoaded', function () {
     // Exit showcase if we were in it
     if (container.classList.contains('showcase')) {
       exitShowcaseMode();
-      container.classList.add('final');
+      container.classList.remove(...ALL_LAYOUT_CLASSES);
+      container.classList.add('plain');
       currentLayout = 0;
+    }
+
+    // Exit solo if stuck
+    if (container.classList.contains('solo')) {
+      exitSoloMode();
+      return;
     }
 
     clearTimeout(loopTimeout);
     await changeLayout();
-    const displayedLayoutIndex = (currentLayout + layouts.length - 1) % layouts.length;
-    const displayedLayoutName = layouts[displayedLayoutIndex];
-    const delay = (displayedLayoutName === 'grid') ? 8000 : 3000;
-    loopTimeout = setTimeout(animationLoop, delay);
   }
 
   // Listen for viewport changes (rotation, resize)
   isMobileQuery.addEventListener('change', (e) => {
     isMobile = e.matches;
     clearTimeout(loopTimeout);
+    clearTimeout(soloTimer);
     stopShowcaseAuto();
 
     if (isMobile) {
+      if (container.classList.contains('solo')) exitSoloMode();
       enterShowcaseMode();
     } else {
       exitShowcaseMode();
-      container.classList.add('final');
+      container.classList.remove(...ALL_LAYOUT_CLASSES);
+      container.classList.add('plain');
       currentLayout = 0;
       gsap.set(letters, { scale: 1, opacity: 1 });
-      loopTimeout = setTimeout(animationLoop, 2000);
+      if (!isPaused) loopTimeout = setTimeout(animationLoop, 2000);
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -66,13 +66,13 @@ body::before {
 }
 
 
-.container, .word {
+.container {
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  flex-wrap: wrap;
-  width: 90vw;
+  flex-wrap: nowrap;
+  width: 96vw;
   max-width: 1200px;
   height: auto;
   min-height: 60vh;
@@ -81,6 +81,14 @@ body::before {
   z-index: 2;
   background: none;
   box-shadow: none;
+}
+
+.word {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .letter {
@@ -184,11 +192,16 @@ body::before {
 
 .container.plain {
   flex-direction: row;
+  flex-wrap: nowrap;
 }
 
 .container.plain .letter {
-  /* background-color: transparent; */
   border: none;
+}
+
+.container.plain .kingdom,
+.container.plain .bahrain {
+  display: none;
 }
 
 .container.columns .letter {
@@ -208,11 +221,16 @@ body::before {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: repeat(3, 1fr);
-  gap: 20px;
-  width: 80%;
-  height: 80%;
-  max-width: 800px;
-  max-height: 800px;
+  gap: 16px;
+  width: 100vw;
+  max-width: 100vw;
+  height: 100vh;
+  max-height: 100vh;
+  margin: 0;
+  padding: 16px;
+  position: fixed;
+  top: 0;
+  left: 0;
 }
 
 .container.grid .letter {
@@ -799,18 +817,17 @@ body::before {
 
   .container.grid {
     grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-    width: 92%;
-    max-width: none;
-    max-height: none;
-    height: auto;
-    min-height: auto;
+    gap: 10px;
+    width: 100vw;
+    max-width: 100vw;
+    height: 100vh;
+    max-height: 100vh;
     padding: 10px;
   }
 
   .container.grid .letter {
     padding: 12px 8px;
-    min-height: 120px;
+    min-height: auto;
   }
 
   .container.grid .narrative {
@@ -886,7 +903,10 @@ body::before {
   .container.grid {
     grid-template-columns: repeat(2, 1fr);
     gap: 8px;
-    width: 96%;
+    width: 100vw;
+    max-width: 100vw;
+    height: 100vh;
+    max-height: 100vh;
     padding: 6px;
   }
 
@@ -961,6 +981,139 @@ body::before {
   }
 }
 
+/* ═══════════════════════════════════════════
+   SOLO LETTER REVEAL (one-by-one after grid)
+   ═══════════════════════════════════════════ */
+.container.solo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  flex-wrap: nowrap;
+}
+
+.container.solo .letter {
+  position: absolute;
+  width: 160px;
+  height: 160px;
+  font-size: 6rem;
+  margin: 0;
+  border-radius: 28px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 0 80px rgba(206, 17, 38, 0.15);
+  backdrop-filter: blur(20px);
+  border: 1.5px solid rgba(255, 255, 255, 0.15);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.container.solo .letter.solo-active {
+  opacity: 1;
+  pointer-events: auto;
+  z-index: 10;
+}
+
+.container.solo .word {
+  display: block !important;
+  position: absolute !important;
+  top: calc(50% + 110px);
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  text-align: center;
+  pointer-events: auto;
+  letter-spacing: 1px;
+  min-width: 280px;
+  z-index: 20;
+}
+
+.container.solo .arabic {
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin-top: 10px;
+  display: block;
+}
+
+.container.solo .narrative {
+  display: block !important;
+  position: absolute !important;
+  top: calc(50% + 200px);
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  margin-top: 0;
+  padding: 22px 28px;
+  pointer-events: auto;
+  max-width: 480px;
+  width: 80vw;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1));
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  z-index: 20;
+}
+
+.container.solo .story-title {
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+}
+
+.container.solo .story-text {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  text-align: center;
+}
+
+.container.solo .kingdom,
+.container.solo .bahrain {
+  display: none !important;
+}
+
+/* ═══════════════════════════════════════════
+   PLAY / PAUSE BUTTON
+   ═══════════════════════════════════════════ */
+.play-pause-btn {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1002;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(206, 17, 38, 0.4);
+  background: rgba(15, 15, 35, 0.8);
+  color: rgba(245, 233, 217, 0.8);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  transition: all 0.25s ease;
+  padding: 0;
+}
+
+.play-pause-btn:hover {
+  transform: translateX(-50%) scale(1.15);
+  border-color: rgba(206, 17, 38, 0.7);
+  box-shadow: 0 4px 20px rgba(206, 17, 38, 0.25);
+  color: #f5e9d9;
+}
+
+.play-pause-btn.paused {
+  border-color: rgba(206, 17, 38, 0.6);
+  background: rgba(206, 17, 38, 0.15);
+}
+
 /* Final Reveal Sequence Styles */
 .final-reveal-active {
   animation: finalDramaticReveal 3s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
@@ -1029,6 +1182,9 @@ body::before {
 .container.grid {
   display: grid;
   place-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
 }
 
 /* ═══════════════════════════════════════════
@@ -1461,5 +1617,44 @@ body::before {
   .swipe-hint {
     bottom: 48px;
     font-size: 0.65rem;
+  }
+
+  .play-pause-btn {
+    bottom: 66px;
+    width: 30px;
+    height: 30px;
+  }
+
+  .play-pause-btn svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  /* Solo mode on small phones */
+  .container.solo .letter {
+    width: 120px;
+    height: 120px;
+    font-size: 4.5rem;
+  }
+
+  .container.solo .word {
+    top: calc(50% + 85px);
+    font-size: 1.5rem;
+    min-width: 200px;
+  }
+
+  .container.solo .narrative {
+    top: calc(50% + 160px);
+    width: 88vw;
+    padding: 16px 14px;
+  }
+
+  .container.solo .story-title {
+    font-size: 1.2rem;
+  }
+
+  .container.solo .story-text {
+    font-size: 0.88rem;
+    line-height: 1.5;
   }
 }


### PR DESCRIPTION
…/pause

Layout order & initial state:
- Start on 'plain' (all 7 letters in a single horizontal row, no wrap)
- Sequence: plain → final → columns → rows → grid → solo → loop
- Container uses flex-wrap: nowrap to guarantee single-row display

Transparency fix:
- ensureLettersVisible() called after every FLIP transition
- Removed opacity from FLIP state capture props
- Letters always stay at opacity: 1 during layout changes

Fullscreen grid:
- Grid now uses position: fixed, 100vw × 100vh with padding
- Fills entire screen on all breakpoints (desktop, tablet, phone)

Solo one-by-one reveal (new phase after grid):
- Each letter appears centered alone on screen (160px card)
- Word fades in slowly below the letter (1.2s ease)
- Narrative fades in below the word (1.4s ease)
- Particles burst on each letter entrance
- Previous letter fades out before next appears
- 6 seconds per letter, then loops back to plain

Play/Pause button:
- Tiny 36px circular button fixed at bottom-center
- Toggles pause/play icons, stops all timers when paused
- Resumes the current phase (showcase, solo, or layout loop)
- Styled consistently with voice/search controls

https://claude.ai/code/session_015zxNntLsJwenmBtqTCsGrx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Play/Pause button to control animation flow.
  * Introduced SOLO mode revealing letters individually with narratives.
  * Expanded layout cycling with multiple presentation modes.
  * Enhanced mobile experience with swipe navigation and improved responsive design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->